### PR TITLE
Spoof pixel build fingerprint to pass safynet

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -278,3 +278,6 @@ BOARD_HAVE_SAMSUNG_WIFI          := true
 
 # Inherit from the proprietary version
 -include vendor/samsung/on7xelte/BoardConfigVendor.mk
+
+# Build fingerprint Raven march 2022
+BUILD_FINGERPRINT := "google/raven/raven:12/S3B1.220218.006/8325196:user/release-keys"


### PR DESCRIPTION
Spoof pixel build fingerprint to pass safynet

Fingerprint must match security patch in order to pass safynet. (in this commit march 2022 build fingerprint)
You can pick a google device fingerprint from nippon gsi : https://t.me/nippongsi